### PR TITLE
Fix crash in some situation on windows

### DIFF
--- a/extension.cpp
+++ b/extension.cpp
@@ -122,6 +122,9 @@ __declspec(naked) void playerspawn()
     __asm test al, al
     __asm jz UseDefaultMdl
 
+#ifdef WIN32
+    __asm lea esi, [g_model]
+#endif
     __asm mov eax, g_addr_model_custom
     __asm jmp eax
 
@@ -152,8 +155,8 @@ bool MdlChagerExt::SDK_OnLoad(char* error, size_t maxlen, bool late)
 
 #ifdef WIN32
     void *addr_hook = (void*)((uintptr_t)addr + 0x6D6);
-    g_addr_model_normal = (void*)((uintptr_t)addr + 0x6FC);
-    g_addr_model_custom = (void*)((uintptr_t)addr + 0x77F);
+    g_addr_model_normal = (void*)((uintptr_t)addr + 0x817);
+    g_addr_model_custom = (void*)((uintptr_t)addr + 0x78B);
 #else
     void *addr_hook = (void*)((uintptr_t)addr + 0x25E);
     g_addr_model_normal = (void*)((uintptr_t)addr + 0x19B0);


### PR DESCRIPTION
The hook position is different from the linux implementation. Use default model skip the the following code and directly call SetModelFromClass(), which was done in loc_10446637.
```asm
cmp     byte ptr [esp+38h+var_24], 0
jnz     loc_10446637
```
Using custom model skip first three line, this explains why moving the g_model address to the esi register.
 ```asm
mov     esi, [esp+38h+var_18]
test    esi, esi
jz      loc_10446637
cmp     byte ptr [esi], 0
jz      loc_10446637
```
The behavior is quite wired when using the same hook position on linux, the crash which was mentioned [here](https://github.com/SAZONISCHE/disable_agent_models/issues/2) was because the code didn't jump to loc_10446637 as expected. And the custom model fix is because then setting model instead of blocking it still crash the server. This was because the model name pointer loaded from the stack is not correct, causes crash. It's wired because the crash is not 100%, it's likely to crash in warmup, sometimes not in the warmup it works fine.

Instead of figuring out what exactly has happened to cause this behavior, I chose to temporarily fix it first, so these changes can fix the crash, and it's been tested working, but I think more test case should be covered before this could be merged, when the test is all done I will upload the binary.